### PR TITLE
adding defaults, pulling the original opal dependency back, as that m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ an input field which autocompletes to one of the above tests. Note you still nee
 Now in the record panel you should be able to click add, type in Smear and you should get a rendered form with the options for
 pathology of positive/negative/not known.
 
-You can override the form template by putting a form at /templates/lab_tests/forms/{{ model api name }}_form.html
+You can override the form template by putting a form at /templates/lab_tests/forms/{{ model api name }}_form.html.
+
+Note at the moment, observations must all have a unique name. This may change in the future.
 
 ### Other fields on LabTest
 
@@ -244,3 +246,7 @@ for example
 class ChestXray(models.LabTest):
     _synonyms = ["CX"]
 ```
+
+### Defaults
+
+Defaults are currently

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ As there are literally thousands of different tests that are used. To stop us fr
 
 We then provide some syntactic sugar so that you can use them as if the observations are fields within the tables.
 
+Note if fields a class has changed test type. Old observations will be discarded on update. Also if observations for a different test type are sent over to the server, these will be ignored.
+
 
 ### Writing Custom Observations
 opal-labs ships with an the most common use cases however its perfectly possible that you'd like to write observations for your specific requirements.
@@ -249,4 +251,4 @@ class ChestXray(models.LabTest):
 
 ### Defaults
 
-Defaults are currently
+Defaults are currently set like you would set a default on an ordinary field.

--- a/lab/migrations/0001_initial.py
+++ b/lab/migrations/0001_initial.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('opal', '0027_auto_20160913_1747'),
+        ('opal', '0025_merge'),
     ]
 
     operations = [

--- a/lab/migrations/0004_auto_20161206_1255.py
+++ b/lab/migrations/0004_auto_20161206_1255.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lab', '0003_auto_20161127_1952'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='observation',
+            name='result',
+            field=models.CharField(default=None, max_length=256, null=True, blank=True),
+        ),
+    ]

--- a/lab/models.py
+++ b/lab/models.py
@@ -502,6 +502,13 @@ class LabTest(ExtrasMixin, omodels.PatientSubrecord):
             od["name"] = observation.name
             observation_data.append(od)
 
+        # because we change the test type in the same form
+        # we have the risk of them returning observations
+        # that have been set, then the test type changed
+        # we'll nuke these here
+        observation_names = set(self.__class__.all_observation_names())
+        data = {k: v for k, v in data.items() if k not in observation_names}
+
         super(LabTest, self).update_from_dict(data, user, **kwargs)
 
         existing_observations = [

--- a/lab/models.py
+++ b/lab/models.py
@@ -253,7 +253,7 @@ class DefaultLabTestMeta(object):
 
 class LabTestMetaclass(CastToProxyClassMetaclass):
     @classmethod
-    def test_no_default_clashes(cls, new_cls, observation_fields):
+    def validate_no_default_clashes(cls, new_cls, observation_fields):
         """
         """
         name_to_observation = {
@@ -302,7 +302,7 @@ class LabTestMetaclass(CastToProxyClassMetaclass):
         new_cls = super(LabTestMetaclass, cls).__new__(cls, name, bases, attrs)
 
         if not name == 'LabTest':
-            cls.test_no_default_clashes(new_cls, observation_fields)
+            cls.validate_no_default_clashes(new_cls, observation_fields)
 
         new_cls._observation_types = observation_fields
         return new_cls

--- a/lab/tests/models.py
+++ b/lab/tests/models.py
@@ -7,7 +7,10 @@ class Smear(models.LabTest):
 
 
 class SampleTest(models.LabTest):
-    some_observation = models.PosNeg(verbose_name="Verbose Name")
+    some_observation = models.PosNeg(
+        verbose_name="Verbose Name",
+        default="+ve"
+    )
 
 
 class SomeTestWithSynonyms(models.LabTest):

--- a/lab/tests/models.py
+++ b/lab/tests/models.py
@@ -16,7 +16,7 @@ class SampleTest(models.LabTest):
 class SomeTestWithSynonyms(models.LabTest):
     _synonyms = ["Also known as"]
     _title = "Some Test With Synonyms"
-    some_observation = models.PosNeg(verbose_name="Verbose Name")
+    some_other_observation = models.PosNeg(verbose_name="Verbose Name")
 
 
 class SomeAbstractTest(models.LabTest, AbstractBase):

--- a/lab/tests/test_models.py
+++ b/lab/tests/test_models.py
@@ -43,6 +43,21 @@ class TestLabTestSave(OpalTestCase):
             "-ve"
         )
 
+    def test_update_removes_other_observations_in_dict(self):
+        data_dict = dict(
+            lab_test_type="Also known as",
+            some_observation=dict(result="-ve"),
+            some_name=dict(result="-ve")
+        )
+        self.assertFalse(models.LabTest.objects.exists())
+        lab_test = models.LabTest(patient=self.patient)
+        lab_test.update_from_dict(data_dict, self.user)
+        found_lab_test = SomeTestWithSynonyms.objects.get()
+        self.assertEqual(
+            found_lab_test.some_observation.result,
+            "-ve"
+        )
+
     def test_to_dict(self):
         lab_test = models.LabTest.objects.create(
             patient=self.patient,

--- a/lab/tests/test_models.py
+++ b/lab/tests/test_models.py
@@ -56,6 +56,21 @@ class TestLabTestSave(OpalTestCase):
         self.assertEqual(result["pathology"]["result"], "-ve")
 
 
+class TestGetSchema(OpalTestCase):
+    def test_build_field_schema(self):
+        with mock.patch.object(models.LabTest, "list") as l:
+            l.return_value = [SampleTest]
+            schema = models.LabTest.build_field_schema()
+
+        obs = [s for s in schema if s["name"] == 'some_observation'][0]
+        self.assertEqual(obs["default"], dict(result="+ve"))
+        self.assertEqual(obs["lookup_list"], None)
+        self.assertEqual(obs["model"], "LabTest")
+        self.assertEqual(obs["name"], 'some_observation')
+        self.assertEqual(obs["title"], 'Some_Observation')
+        self.assertEqual(obs["type"], 'p')
+
+
 class TestVerboseName(OpalTestCase):
     def setUp(self):
         self.patient, _ = self.new_patient_and_episode_please()
@@ -75,6 +90,12 @@ class TestVerboseName(OpalTestCase):
             patient=self.patient,
             lab_test_type=SampleTest.get_display_name()
         )
+
+
+class TestGetField(OpalTestCase):
+    def test_gets_field(self):
+        field = models.LabTest._get_field("some_observation")
+        self.assertEqual(field.name, "some_observation")
 
 
 class TestInheritance(OpalTestCase):

--- a/lab/tests/test_models.py
+++ b/lab/tests/test_models.py
@@ -281,7 +281,7 @@ class TestGetFormTemplate(OpalTestCase):
             ['lab/forms/smear_form.html', 'lab/forms/form_base.html']
         )
 
-        
+
 class TestDefaults(OpalTestCase):
     def test_error_on_different_observation_defaults(self):
         # if we have two observations with the same name but different defaults then
@@ -297,12 +297,12 @@ class TestDefaults(OpalTestCase):
         other_observation.get_default = mock.MagicMock(return_value='left')
 
         with self.assertRaises(ValueError):
-            models.LabTestMetaclass.test_no_default_clashes(
+            models.LabTestMetaclass.validate_no_default_clashes(
                 new_cls,
                 [other_observation]
             )
 
-            
+
 class TestObservations(OpalTestCase):
     def setUp(self):
         self.patient, _ = self.new_patient_and_episode_please()


### PR DESCRIPTION
…igration must sit on a branch.

I'm slightly worried that fields now have to have a unique name. In practice this may not be a big deal as we can use verbose name. Also when we're actually doing the extract, for the time being we probably want a unique name...

